### PR TITLE
devise.rbのエラー解消

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -296,6 +296,8 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
-  config.omniauth :facebook, Rails.application.credentials.facebook[:FACEBOOK_CLIENT_ID], Rails.application.credentials.facebook[:FACEBOOK_CLIENT_SECRET]
-  config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_ID']
+  
+  # fork後SNS認証でerrorになるので以下の2行をコメントアウト
+  # config.omniauth :facebook, Rails.application.credentials.facebook[:FACEBOOK_CLIENT_ID], Rails.application.credentials.facebook[:FACEBOOK_CLIENT_SECRET]
+  # config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_ID']
 end


### PR DESCRIPTION
### **WHAT**
devise.rbの299と300行目(現在の301と302行目)をコメントアウト

### **WHY**
rails sをしたところ、devise.rbの299行目が原因でエラーが出るため